### PR TITLE
Return Promise from Assertions

### DIFF
--- a/src/asserts/toDispatchActionsWithState.js
+++ b/src/asserts/toDispatchActionsWithState.js
@@ -2,7 +2,13 @@ import { performAssertion } from './utils/performAssertion';
 import { assertDispatchedActions } from './utils/assertDispatchedActions';
 
 function toDispatchActionsWithState(initialState, action, expectedActions, done, fail) {
-  performAssertion(assertDispatchedActions, initialState, action, expectedActions, done, fail);
+  return performAssertion(
+    assertDispatchedActions,
+    initialState,
+    action,
+    expectedActions,
+    done, fail
+  );
 }
 
 export { toDispatchActionsWithState };

--- a/src/asserts/toNotDispatchActionsWithState.js
+++ b/src/asserts/toNotDispatchActionsWithState.js
@@ -2,7 +2,13 @@ import { performAssertion } from './utils/performAssertion';
 import { assertNotDispatchedActions } from './utils/assertNotDispatchedActions';
 
 function toNotDispatchActionsWithState(initialState, action, expectedActions, done, fail) {
-  performAssertion(assertNotDispatchedActions, initialState, action, expectedActions, done, fail);
+  return performAssertion(
+    assertNotDispatchedActions,
+    initialState,
+    action,
+    expectedActions,
+    done, fail
+  );
 }
 
 export { toNotDispatchActionsWithState };

--- a/test/asserts/toDispatchActionsWithState.js
+++ b/test/asserts/toDispatchActionsWithState.js
@@ -10,9 +10,11 @@ describe('toDispatchActionsWithState', () => {
   const expectedAction = { expectedAction: 'expectedAction' };
   const spyDone = expect.createSpy();
   const spyFail = expect.createSpy();
+  const performAssertionResult = { result: 'result' };
 
   beforeEach(() => {
-    expect.spyOn(performAssertionObj, 'performAssertion');
+    expect.spyOn(performAssertionObj, 'performAssertion')
+          .andReturn(performAssertionResult);
     expect.spyOn(assertDispatchedActionsObj, 'assertDispatchedActions');
   });
 
@@ -26,12 +28,23 @@ describe('toDispatchActionsWithState', () => {
     toDispatchActionsWithState(initialState, actualAction, expectedAction, spyDone, spyFail);
 
     expect(performAssertionObj.performAssertion).toHaveBeenCalledWith(
-        assertDispatchedActionsObj.assertDispatchedActions,
-        initialState,
-        actualAction,
-        expectedAction,
-        spyDone,
-        spyFail
+      assertDispatchedActionsObj.assertDispatchedActions,
+      initialState,
+      actualAction,
+      expectedAction,
+      spyDone,
+      spyFail
       );
+  });
+
+  it('should return result of performAssertion', () => {
+    const result = toDispatchActionsWithState(
+      initialState,
+      actualAction,
+      expectedAction,
+      spyDone, spyFail
+    );
+
+    expect(result).toBe(performAssertionResult);
   });
 });

--- a/test/asserts/toNotDispatchActionsWithState.js
+++ b/test/asserts/toNotDispatchActionsWithState.js
@@ -10,9 +10,11 @@ describe('toNotDispatchActionsWithState', () => {
   const expectedAction = { expectedAction: 'expectedAction' };
   const spyDone = expect.createSpy();
   const spyFail = expect.createSpy();
+  const performAssertionResult = { result: 'result' };
 
   beforeEach(() => {
-    expect.spyOn(performAssertionObj, 'performAssertion');
+    expect.spyOn(performAssertionObj, 'performAssertion')
+          .andReturn(performAssertionResult);
     expect.spyOn(assertNotDispatchedActionsObj, 'assertNotDispatchedActions');
   });
 
@@ -26,12 +28,23 @@ describe('toNotDispatchActionsWithState', () => {
     toNotDispatchActionsWithState(initialState, actualAction, expectedAction, spyDone, spyFail);
 
     expect(performAssertionObj.performAssertion).toHaveBeenCalledWith(
-        assertNotDispatchedActionsObj.assertNotDispatchedActions,
-        initialState,
-        actualAction,
-        expectedAction,
-        spyDone,
-        spyFail
+      assertNotDispatchedActionsObj.assertNotDispatchedActions,
+      initialState,
+      actualAction,
+      expectedAction,
+      spyDone,
+      spyFail
       );
+  });
+
+  it('should return result of performAssertion', () => {
+    const result = toNotDispatchActionsWithState(
+      initialState,
+      actualAction,
+      expectedAction,
+      spyDone, spyFail
+    );
+
+    expect(result).toBe(performAssertionResult);
   });
 });


### PR DESCRIPTION
Return a promise from assertion to allow chaining of assertions and [Promise-based async tests](https://mochajs.org/#working-with-promises)

Related issues:
- https://github.com/redux-things/redux-actions-assertions/issues/16
- https://github.com/redux-things/redux-actions-assertions/issues/24

Old usage (mocha + expect):

``` javascript
it('<test name>',(done)=>{
  expect(fetchData()).toDispatchActions(expectedActions, done);
});
```

New usage (mocha + expect):

``` javascript
it('<test name>',()=>{
  return expect(fetchData()).toDispatchActions(expectedActions).then(()=>{
    expect(api.fetch).toHaveBeenCalled('/url');
  });
});
```
