### PR TITLE
Accept function as initial state for assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "lodash.findindex": "^4.4.0",
     "lodash.flattendeep": "^4.2.0",
     "redux": "^3.5.2",

--- a/src/asserts/toDispatchActionsWithState.js
+++ b/src/asserts/toDispatchActionsWithState.js
@@ -1,7 +1,10 @@
+import { getInitialStoreState } from '../initialState';
+import { isFunction } from '../utils';
 import { performAssertion } from './utils/performAssertion';
 import { assertDispatchedActions } from './utils/assertDispatchedActions';
 
-function toDispatchActionsWithState(initialState, action, expectedActions, done, fail) {
+function toDispatchActionsWithState(state, action, expectedActions, done, fail) {
+  const initialState = isFunction(state) ? state(getInitialStoreState()) : state;
   return performAssertion(
     assertDispatchedActions,
     initialState,

--- a/src/asserts/toNotDispatchActionsWithState.js
+++ b/src/asserts/toNotDispatchActionsWithState.js
@@ -1,7 +1,10 @@
+import { getInitialStoreState } from '../initialState';
+import { isFunction } from '../utils';
 import { performAssertion } from './utils/performAssertion';
 import { assertNotDispatchedActions } from './utils/assertNotDispatchedActions';
 
-function toNotDispatchActionsWithState(initialState, action, expectedActions, done, fail) {
+function toNotDispatchActionsWithState(state, action, expectedActions, done, fail) {
+  const initialState = isFunction(state) ? state(getInitialStoreState()) : state;
   return performAssertion(
     assertNotDispatchedActions,
     initialState,

--- a/src/initialState.js
+++ b/src/initialState.js
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash.cloneDeep';
 import { createStore } from 'redux';
 
 let state = null;
@@ -12,7 +13,7 @@ function buildInitialStoreState(reducer) {
 }
 
 function getInitialStoreState() {
-  return state;
+  return cloneDeep(state);
 }
 
 export {

--- a/src/initialState.js
+++ b/src/initialState.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.cloneDeep';
+import cloneDeep from 'lodash.clonedeep';
 import { createStore } from 'redux';
 
 let state = null;

--- a/test/asserts/toDispatchActionsWithState.js
+++ b/test/asserts/toDispatchActionsWithState.js
@@ -70,7 +70,7 @@ describe('toDispatchActionsWithState', () => {
       expect(stateFunction).toHaveBeenCalledWith(initialState);
     });
 
-    it('should call performAssertion with result of state function as initial state', () => {
+    it('should call performAssertion with result from state function as initial state', () => {
       toDispatchActionsWithState(
         stateFunction,
         actualAction,

--- a/test/asserts/toNotDispatchActionsWithState.js
+++ b/test/asserts/toNotDispatchActionsWithState.js
@@ -47,4 +47,42 @@ describe('toNotDispatchActionsWithState', () => {
 
     expect(result).toBe(performAssertionResult);
   });
+
+  describe('when state is a function', () => {
+    const stateFunctionResult = { newResult: 'newResult' };
+    let stateFunction;
+
+    beforeEach(() => {
+      stateFunction = expect.createSpy().andReturn(stateFunctionResult);
+    });
+
+    it('should execute it with initial state as argument', () => {
+      toNotDispatchActionsWithState(
+        stateFunction,
+        actualAction,
+        expectedAction,
+        spyDone, spyFail
+      );
+
+      expect(stateFunction).toHaveBeenCalledWith(initialState);
+    });
+
+    it('should call performAssertion with result from state function as initial state', () => {
+      toNotDispatchActionsWithState(
+        stateFunction,
+        actualAction,
+        expectedAction,
+        spyDone, spyFail
+      );
+
+      expect(performAssertionObj.performAssertion).toHaveBeenCalledWith(
+        assertNotDispatchedActionsObj.assertNotDispatchedActions,
+        stateFunctionResult,
+        actualAction,
+        expectedAction,
+        spyDone,
+        spyFail
+      );
+    });
+  });
 });

--- a/test/general/initialState.js
+++ b/test/general/initialState.js
@@ -28,6 +28,14 @@ describe('initialState', () => {
       it('should return registered value', () => {
         expect(getInitialStoreState()).toEqual(initialStoreState);
       });
+
+      it('should return deep clone of registered value', () => {
+        const initialState = getInitialStoreState();
+        initialState.newInitialStoreStateKey = 'newInitialStoreStateKey';
+
+        expect(getInitialStoreState().newInitialStoreStateKey)
+          .toNotEqual(initialState.newInitialStoreStateKey);
+      });
     });
   });
 


### PR DESCRIPTION
- Accept function as initial state for assertion to allow initial state enhancement per test
- `getInitialStoreState` returns deep copy of initial state, to avoid mutations

Related issues:
https://github.com/redux-things/redux-actions-assertions/issues/9
