### PR TITLE
Fixed error description with async/await. Added check for empty expectedActions

### DIFF
--- a/src/asserts/utils/assertDispatchedActions.js
+++ b/src/asserts/utils/assertDispatchedActions.js
@@ -4,6 +4,10 @@ import { notDispatchedActionError } from '../errors/notDispatchedActionError';
 function assertDispatchedActions(dispatched, expected) {
   const availableActions = dispatched.slice();
 
+  if (expected.length === 0 && dispatched.length > 0) {
+    throw notDispatchedActionError(dispatched, expected, {});
+  }
+
   for (let indexInExpected = 0; indexInExpected < expected.length; indexInExpected++) {
     const indexInAvailable = findIndex(availableActions, expected[indexInExpected]);
 

--- a/src/asserts/utils/performAssertion.js
+++ b/src/asserts/utils/performAssertion.js
@@ -34,7 +34,7 @@ function performAssertion(assertFunction, initialState, action, expectedActions,
       done(err);
       return;
     }
-    throw new Error(JSON.stringify(err));
+    throw err;
   });
 }
 


### PR DESCRIPTION
When calling expectedActions inside a async/await function the error displayed was a empty object. With this fix you can see the error again. 

There was also a condition that when the expectedActions array should be empty and a actionCreator returned a action, the test still passed.